### PR TITLE
Fix Readme Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ sudo usermod -aG docker iothon
 ## Clone this repository
 
 ```
-git clone git@github.com:Miceuz/docker-compose-mosquitto-influxdb-telegraf-grafana.git 
+git clone https://github.com/Miceuz/docker-compose-mosquitto-influxdb-telegraf-grafana.git
 ```
 
 ## Run it

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ git clone https://github.com/Miceuz/docker-compose-mosquitto-influxdb-telegraf-g
 To download, setup and start all the services run
 ```
 cd docker-compose-mosquitto-influxdb-telegraf-grafana
-sudo docker-compose up -d`
+sudo docker-compose up -d
 ```
 
 To check the running setvices run


### PR DESCRIPTION
If you use ssh to clone the repo you get an "Permission denied" error. This PR fixes the Readme instructions to use https.


![image](https://github.com/Miceuz/docker-compose-mosquitto-influxdb-telegraf-grafana/assets/54598714/e91ce281-f6e4-43aa-bba5-a65083b3cfbd)


(and it removes the wrong `) 